### PR TITLE
Update portfolio method and documentation

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -158,6 +158,7 @@ Get an account portfolio
 | Param | Type | Description |
 | --- | --- | --- |
 | credentials | [<code>Credentials</code>](#Credentials) | User's account credentials |
+| account_id | <code>string</code> | The ID of the account you are trying to get the porfolio for (can be found under accounts from userDetails) |
 
 <a name="Stash.buy"></a>
 

--- a/index.js
+++ b/index.js
@@ -103,9 +103,10 @@ class Stash {
     /**
      * Get an account portfolio
      * @param {Credentials} credentials - User's account credentials
+     * @param {string} account_id - The ID of the account you are trying to get the porfolio for (can be found under accounts from userDetails)
      */
-    static portfolio(credentials) {
-        return request.get(`users/${credentials.user_id}/accounts/${credentials.uuid}/portfolio`, credentials.access_token);
+    static portfolio(credentials, account_id) {
+        return request.get(`users/${credentials.user_id}/accounts/${account_id}/portfolio`, credentials.access_token);
     }
 
     /**


### PR DESCRIPTION
Previously, the portfolio method could call 
`users/${credentials.user_id}/accounts/${credentials.uuid}/portfolio` which would result in a 400 `{ success: false, status: 400, errors: 'Record not found.' }` error. After looking at the network calls on the site I have found that the correct call it to use the ID of the investment account in place of a user's account. I have added the account_id to the parameters of the portfolio function, updated the call, and updated the documentation. 